### PR TITLE
ATO-899: Prepare to remove PublicBeta config

### DIFF
--- a/self-service/config.template.yml
+++ b/self-service/config.template.yml
@@ -365,8 +365,6 @@ Resources:
 
   PublicBetaSignupSheetDataRangeParameter:
     Type: AWS::SSM::Parameter
-    DeletionPolicy: "Retain"
-    UpdateReplacePolicy: "Retain"
     Properties:
       Name: !Join
         - "/"
@@ -383,8 +381,6 @@ Resources:
 
   PublicBetaSheetHeaderRangeParameter:
     Type: AWS::SSM::Parameter
-    DeletionPolicy: "Retain"
-    UpdateReplacePolicy: "Retain"
     Properties:
       Name: !Join
         - "/"


### PR DESCRIPTION
We're removing the Register to Join Public beta form, so this removes the retain and deletion policies for these parameters to prepare them for deletion
